### PR TITLE
Reduce hint label width to prevent Lato overdraw

### DIFF
--- a/java/res/values/dimens.xml
+++ b/java/res/values/dimens.xml
@@ -54,7 +54,7 @@
     <fraction name="key_label_ratio">34%</fraction>
     <fraction name="key_large_label_ratio">40%</fraction>
     <fraction name="key_hint_letter_ratio">25%</fraction>
-    <fraction name="key_hint_label_ratio">44%</fraction>
+    <fraction name="key_hint_label_ratio">40%</fraction>
     <fraction name="key_uppercase_letter_ratio">35%</fraction>
     <fraction name="key_preview_text_ratio">82%</fraction>
     <fraction name="spacebar_text_ratio">33.735%</fraction>


### PR DESCRIPTION
The 'WXYZ' hint label in the 9 pad is slightly too wide when Lato
is applied, causing the label to be drawn a little outside the button.

Change-Id: Ie597feecf44d47a1e52529dc0e86880ba34f1bf2
